### PR TITLE
Fix order type argument in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ dhan.place_forever(
     exchange_segment= dhan.NSE,
     transaction_type= dhan.BUY,
     product_type=dhan.CNC,
-    product_type= dhan.LIMIT,
+    order_type=dhan.LIMIT,
     quantity= 10,
     price= 1900,
     trigger_Price= 1950


### PR DESCRIPTION
## Summary
- fix copy-pasted argument in the `place_forever` example

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851b2807df083219ccacd57e78777ea