### PR TITLE
Fix correlationID method name

### DIFF
--- a/PKG-INFO
+++ b/PKG-INFO
@@ -61,7 +61,7 @@ DhanHQ v2 extends execution capability with live order updates, market quotes an
 
 - `historical_daily_data` takes `security_id` as argument instead of `symbol`
 
-- Nomenclature changes in `get_order_by_corelationID` to `get_order_by_correlationID`.
+- Nomenclature change: use `get_order_by_correlationID`.
 
 You can read about all other updates from DhanHQ V2 here: [DhanHQ Releases](https://dhanhq.co/docs/v2/releases/).
 
@@ -143,7 +143,7 @@ dhan.modify_order(order_id, order_type, leg_name, quantity, price, trigger_price
 dhan.cancel_order(order_id)
 
 # Get order by correlation id
-dhan.get_order_by_corelationID(corelationID)
+dhan.get_order_by_correlationID(correlationID)
 
 # Get Instrument List
 dhan.fetch_security_list("compact")

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ DhanHQ v2 extends execution capability with live order updates, market quotes an
 
 - `historical_daily_data` takes `security_id` as argument instead of `symbol`
 
-- Nomenclature changes in `get_order_by_corelationID` to `get_order_by_correlationID`.
+- Nomenclature change: use `get_order_by_correlationID`.
 
 You can read about all other updates from DhanHQ V2 here: [DhanHQ Releases](https://dhanhq.co/docs/v2/releases/).
 
@@ -128,7 +128,7 @@ dhan.modify_order(order_id, order_type, leg_name, quantity, price, trigger_price
 dhan.cancel_order(order_id)
 
 # Get order by correlation id
-dhan.get_order_by_corelationID(corelationID)
+dhan.get_order_by_correlationID(correlationID)
 
 # Get Instrument List
 dhan.fetch_security_list("compact")

--- a/dhanhq.egg-info/PKG-INFO
+++ b/dhanhq.egg-info/PKG-INFO
@@ -61,7 +61,7 @@ DhanHQ v2 extends execution capability with live order updates, market quotes an
 
 - `historical_daily_data` takes `security_id` as argument instead of `symbol`
 
-- Nomenclature changes in `get_order_by_corelationID` to `get_order_by_correlationID`.
+- Nomenclature change: use `get_order_by_correlationID`.
 
 You can read about all other updates from DhanHQ V2 here: [DhanHQ Releases](https://dhanhq.co/docs/v2/releases/).
 
@@ -143,7 +143,7 @@ dhan.modify_order(order_id, order_type, leg_name, quantity, price, trigger_price
 dhan.cancel_order(order_id)
 
 # Get order by correlation id
-dhan.get_order_by_corelationID(corelationID)
+dhan.get_order_by_correlationID(correlationID)
 
 # Get Instrument List
 dhan.fetch_security_list("compact")

--- a/examples/orders.py
+++ b/examples/orders.py
@@ -103,7 +103,7 @@ dhan.modify_order(
 dhan.cancel_order(order_id)
 
 # Get order by correlation id
-dhan.get_order_by_corelationID(correlationID)
+dhan.get_order_by_correlationID(correlationID)
 
 # Get trade book
 dhan.get_trade_book()


### PR DESCRIPTION
## Summary
- fix typos in method name `get_order_by_correlationID` across docs and examples
- keep distribution metadata consistent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851b5e8d1148321adb6c6ce41da49ff