### PR TITLE
Fix docstring parameter name

### DIFF
--- a/dhanhq/dhanhq.py
+++ b/dhanhq/dhanhq.py
@@ -165,10 +165,10 @@ class dhanhq:
 
     def get_order_by_correlationID(self, correlationID):
         """
-        Retrieve the order status using a field called correlation ID.
+        Retrieve the order status using a field called ``correlationID``.
 
         Args:
-            corelationID (str): The correlation ID provided during order placement.
+            correlationID (str): The ``correlationID`` provided during order placement.
 
         Returns:
             dict: The response containing order status.


### PR DESCRIPTION
## Summary
- fix get_order_by_correlationID docstring to use correlationID consistently

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851b5ebd1a88321a086d0b1946cad9a