### PR TITLE
Add Super Order APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,11 @@ REST APIs based market quotes which given you snapshot of ticker mode, quote mod
 * **Option Chain**  
 Single function which gives entire Option Chain across exchanges and segments, giving OI, greeks, volume, top bid/ask and price data.
 
-* **Forever Order**  
+* **Forever Order**
 Place, modify or delete Forever Orders, whether single or OCO to better manage your swing trades.
+
+* **Super Order**
+Advanced bracket orders with target and stop loss legs that can be managed via API.
 
 * **Portfolio Management**  
 With this set of APIs, retrieve your holdings and positions in your portfolio as well as manage them.
@@ -197,6 +200,22 @@ dhan.place_forever(
     price= 1900,
     trigger_Price= 1950
 )
+
+# Place Super Order
+dhan.place_super_order(
+    security_id="1333",
+    exchange_segment=dhan.NSE,
+    transaction_type=dhan.BUY,
+    product_type=dhan.INTRA,
+    order_type=dhan.LIMIT,
+    quantity=10,
+    price=1900,
+    trigger_price=1895,
+    target=1950,
+    stop_loss=1880
+)
+# Required parameters: security_id, exchange_segment, transaction_type,
+# product_type, order_type, quantity, price, target and stop_loss
 ```
 
 ### Market Feed Usage

--- a/dhanhq/dhanhq.py
+++ b/dhanhq/dhanhq.py
@@ -681,6 +681,100 @@ class dhanhq:
                 "data": "",
             }
 
+    def get_super_orders(self):
+        """Retrieve a list of all existing Super Orders."""
+        try:
+            url = self.base_url + "/super/orders"
+            response = self.session.get(url, headers=self.header, timeout=self.timeout)
+            return self._parse_response(response)
+        except Exception as e:
+            logging.error("Exception in dhanhq>>get_super_orders : %s", e)
+            return {"status": "failure", "remarks": str(e), "data": ""}
+
+    def place_super_order(
+        self,
+        security_id,
+        exchange_segment,
+        transaction_type,
+        product_type,
+        order_type,
+        quantity,
+        price,
+        trigger_price,
+        target,
+        stop_loss,
+        tag=None,
+    ):
+        """Place a new Super Order in the Dhan account."""
+        try:
+            url = self.base_url + "/super/orders"
+            payload = {
+                "dhanClientId": self.client_id,
+                "securityId": security_id,
+                "exchangeSegment": exchange_segment.upper(),
+                "transactionType": transaction_type.upper(),
+                "productType": product_type.upper(),
+                "orderType": order_type.upper(),
+                "quantity": int(quantity),
+                "price": float(price),
+                "triggerPrice": float(trigger_price),
+                "targetPrice": float(target),
+                "stopLossPrice": float(stop_loss),
+            }
+            if tag:
+                payload["correlationId"] = tag
+            payload = json_dumps(payload)
+            response = self.session.post(url, headers=self.header, timeout=self.timeout, data=payload)
+            return self._parse_response(response)
+        except Exception as e:
+            logging.error("Exception in dhanhq>>place_super_order: %s", e)
+            return {"status": "failure", "remarks": str(e), "data": ""}
+
+    def modify_super_order(
+        self,
+        order_id,
+        leg_name,
+        quantity=None,
+        price=None,
+        trigger_price=None,
+        target=None,
+        stop_loss=None,
+    ):
+        """Modify an existing Super Order."""
+        try:
+            url = self.base_url + f"/super/orders/{order_id}"
+            payload = {
+                "dhanClientId": self.client_id,
+                "orderId": str(order_id),
+                "legName": leg_name,
+            }
+            if quantity is not None:
+                payload["quantity"] = int(quantity)
+            if price is not None:
+                payload["price"] = float(price)
+            if trigger_price is not None:
+                payload["triggerPrice"] = float(trigger_price)
+            if target is not None:
+                payload["targetPrice"] = float(target)
+            if stop_loss is not None:
+                payload["stopLossPrice"] = float(stop_loss)
+            payload = json_dumps(payload)
+            response = self.session.put(url, headers=self.header, timeout=self.timeout, data=payload)
+            return self._parse_response(response)
+        except Exception as e:
+            logging.error("Exception in dhanhq>>modify_super_order: %s", e)
+            return {"status": "failure", "remarks": str(e), "data": ""}
+
+    def cancel_super_order(self, order_id):
+        """Cancel a Super Order using the order ID."""
+        try:
+            url = self.base_url + f"/super/orders/{order_id}"
+            response = self.session.delete(url, headers=self.header, timeout=self.timeout)
+            return self._parse_response(response)
+        except Exception as e:
+            logging.error("Exception in dhanhq>>cancel_super_order: %s", e)
+            return {"status": "failure", "remarks": str(e), "data": ""}
+
     def generate_tpin(self):
         """
         Generate T-Pin on registered mobile number.
@@ -739,7 +833,7 @@ class dhanhq:
             form_html = form_html.replace("\\", "")
             with open("temp_form.html", "w") as f:
                 f.write(form_html)
-            filename = f"file:\\\{Path.cwd()}\\temp_form.html"
+            filename = f"file:///{Path.cwd()}/temp_form.html"
             web_open(filename)
             return self._parse_response(response)
         except Exception as e:

--- a/tests/test_dhanhq.py
+++ b/tests/test_dhanhq.py
@@ -35,3 +35,69 @@ def test_get_positions_success():
 
     assert resp['status'] == 'success'
     assert resp['data'] == {"positions": []}
+
+
+@responses.activate
+def test_get_super_orders_success():
+    api = dhanhq('CID', 'TOKEN')
+    url = api.base_url + '/super/orders'
+    responses.add(responses.GET, url, json={"orders": []}, status=200)
+
+    resp = api.get_super_orders()
+
+    assert resp['status'] == 'success'
+    assert resp['data'] == {"orders": []}
+
+
+@responses.activate
+def test_place_super_order_success():
+    api = dhanhq('CID', 'TOKEN')
+    url = api.base_url + '/super/orders'
+    responses.add(responses.POST, url, json={"id": "1"}, status=200)
+
+    resp = api.place_super_order(
+        security_id='1',
+        exchange_segment=api.NSE,
+        transaction_type=api.BUY,
+        product_type=api.INTRA,
+        order_type=api.LIMIT,
+        quantity=1,
+        price=10,
+        trigger_price=9,
+        target=12,
+        stop_loss=8
+    )
+
+    assert resp['status'] == 'success'
+    assert resp['data'] == {"id": "1"}
+
+    sent = json.loads(responses.calls[0].request.body)
+    assert sent['dhanClientId'] == 'CID'
+    assert sent['securityId'] == '1'
+
+
+@responses.activate
+def test_modify_super_order_success():
+    api = dhanhq('CID', 'TOKEN')
+    url = api.base_url + '/super/orders/123'
+    responses.add(responses.PUT, url, json={"ok": True}, status=200)
+
+    resp = api.modify_super_order('123', leg_name='ENTRY_LEG', price=11)
+
+    assert resp['status'] == 'success'
+
+    sent = json.loads(responses.calls[0].request.body)
+    assert sent['orderId'] == '123'
+    assert sent['price'] == 11
+
+
+@responses.activate
+def test_cancel_super_order_success():
+    api = dhanhq('CID', 'TOKEN')
+    url = api.base_url + '/super/orders/123'
+    responses.add(responses.DELETE, url, json={"status": "cancelled"}, status=200)
+
+    resp = api.cancel_super_order('123')
+
+    assert resp['status'] == 'success'
+    assert resp['data'] == {"status": "cancelled"}


### PR DESCRIPTION
## Summary
- implement super order management
- document usage in README
- test super order routes

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851b9917ef08321aef846575c4f6e39