### PR TITLE
Add aiohttp-based async client

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,27 @@ dhan.place_super_order(
 # product_type, order_type, quantity, price, target and stop_loss
 ```
 
+### Async Usage
+```python
+import asyncio
+from dhanhq.async_client import AsyncDhanHQ
+
+async def main():
+    api = AsyncDhanHQ("client_id", "access_token")
+    await api.place_order(
+        security_id="1333",
+        exchange_segment=api.NSE,
+        transaction_type=api.BUY,
+        quantity=1,
+        order_type=api.MARKET,
+        product_type=api.INTRA,
+        price=0,
+    )
+    await api.close()
+
+asyncio.run(main())
+```
+
 ### Market Feed Usage
 ```python
 from dhanhq import marketfeed

--- a/dhanhq/__init__.py
+++ b/dhanhq/__init__.py
@@ -1,3 +1,6 @@
 """DhanHQ package."""
 
+from .dhanhq import dhanhq
+from .async_client import AsyncDhanHQ
 
+__all__ = ["dhanhq", "AsyncDhanHQ"]

--- a/dhanhq/async_client.py
+++ b/dhanhq/async_client.py
@@ -1,0 +1,273 @@
+import logging
+import aiohttp
+from json import loads as json_loads, dumps as json_dumps
+
+
+class AsyncDhanHQ:
+    """Asynchronous version of :class:`dhqnhq.dhanhq` using ``aiohttp``."""
+
+    NSE = "NSE_EQ"
+    BSE = "BSE_EQ"
+    CUR = "NSE_CURRENCY"
+    MCX = "MCX_COMM"
+    FNO = "NSE_FNO"
+    NSE_FNO = "NSE_FNO"
+    BSE_FNO = "BSE_FNO"
+    INDEX = "IDX_I"
+
+    BUY = "BUY"
+    SELL = "SELL"
+
+    CNC = "CNC"
+    INTRA = "INTRADAY"
+    MARGIN = "MARGIN"
+    CO = "CO"
+    BO = "BO"
+    MTF = "MTF"
+
+    LIMIT = "LIMIT"
+    MARKET = "MARKET"
+    SL = "STOP_LOSS"
+    SLM = "STOP_LOSS_MARKET"
+
+    DAY = "DAY"
+    IOC = "IOC"
+
+    def __init__(self, client_id, access_token, disable_ssl=False, session=None):
+        self.client_id = str(client_id)
+        self.access_token = access_token
+        self.base_url = "https://api.dhan.co/v2"
+        self.timeout = aiohttp.ClientTimeout(total=60)
+        self.header = {
+            "access-token": access_token,
+            "Content-type": "application/json",
+            "Accept": "application/json",
+        }
+        self.disable_ssl = disable_ssl
+        self.session = session or aiohttp.ClientSession(timeout=self.timeout)
+        self._session_owner = session is None
+
+    async def close(self):
+        if self._session_owner:
+            await self.session.close()
+
+    async def _parse_response(self, response):
+        try:
+            status = "failure"
+            remarks = ""
+            data = ""
+            python_response = await response.json(content_type=None)
+            if response.status == 200:
+                status = "success"
+                data = python_response
+            else:
+                remarks = {
+                    "error_code": python_response.get("errorCode"),
+                    "error_type": python_response.get("errorType"),
+                    "error_message": python_response.get("errorMessage"),
+                }
+                data = python_response
+        except Exception as e:
+            logging.warning("Exception in AsyncDhanHQ>>_parse_response: %s", e)
+            status = "failure"
+            remarks = str(e)
+        return {"status": status, "remarks": remarks, "data": data}
+
+    def _ssl(self):
+        return False if self.disable_ssl else None
+
+    async def get_order_list(self):
+        try:
+            url = self.base_url + "/orders"
+            resp = await self.session.get(url, headers=self.header, ssl=self._ssl())
+            return await self._parse_response(resp)
+        except Exception as e:
+            logging.error("Exception in AsyncDhanHQ>>get_order_list : %s", e)
+            return {"status": "failure", "remarks": str(e), "data": ""}
+
+    async def get_order_by_id(self, order_id):
+        try:
+            url = self.base_url + f"/orders/{order_id}"
+            resp = await self.session.get(url, headers=self.header, ssl=self._ssl())
+            return await self._parse_response(resp)
+        except Exception as e:
+            logging.error("Exception in AsyncDhanHQ>>get_order_by_id : %s", e)
+            return {"status": "failure", "remarks": str(e), "data": ""}
+
+    async def place_order(
+        self,
+        security_id,
+        exchange_segment,
+        transaction_type,
+        quantity,
+        order_type,
+        product_type,
+        price,
+        trigger_price=0,
+        disclosed_quantity=0,
+        after_market_order=False,
+        validity="DAY",
+        amo_time="OPEN",
+        bo_profit_value=None,
+        bo_stop_loss_Value=None,
+        tag=None,
+    ):
+        try:
+            url = self.base_url + "/orders"
+            payload = {
+                "dhanClientId": self.client_id,
+                "transactionType": transaction_type.upper(),
+                "exchangeSegment": exchange_segment.upper(),
+                "productType": product_type.upper(),
+                "orderType": order_type.upper(),
+                "validity": validity.upper(),
+                "securityId": security_id,
+                "quantity": int(quantity),
+                "disclosedQuantity": int(disclosed_quantity),
+                "price": float(price),
+                "afterMarketOrder": after_market_order,
+                "boProfitValue": bo_profit_value,
+                "boStopLossValue": bo_stop_loss_Value,
+            }
+            if tag:
+                payload["correlationId"] = tag
+            if after_market_order:
+                if amo_time in ["PRE_OPEN", "OPEN", "OPEN_30", "OPEN_60"]:
+                    payload["amoTime"] = amo_time
+                else:
+                    raise Exception(
+                        "amo_time value must be ['PRE_OPEN','OPEN','OPEN_30','OPEN_60']"
+                    )
+            if trigger_price > 0:
+                payload["triggerPrice"] = float(trigger_price)
+            else:
+                payload["triggerPrice"] = 0.0
+
+            resp = await self.session.post(
+                url, data=json_dumps(payload), headers=self.header, ssl=self._ssl()
+            )
+            return await self._parse_response(resp)
+        except Exception as e:
+            logging.error("Exception in AsyncDhanHQ>>place_order: %s", e)
+            return {"status": "failure", "remarks": str(e), "data": ""}
+
+    async def get_positions(self):
+        try:
+            url = self.base_url + "/positions"
+            resp = await self.session.get(url, headers=self.header, ssl=self._ssl())
+            return await self._parse_response(resp)
+        except Exception as e:
+            logging.error("Exception in AsyncDhanHQ>>get_positions: %s", e)
+            return {"status": "failure", "remarks": str(e), "data": ""}
+
+    async def intraday_minute_data(
+        self,
+        security_id,
+        exchange_segment,
+        instrument_type,
+        from_date,
+        to_date,
+        interval=1,
+    ):
+        try:
+            url = self.base_url + "/charts/intraday"
+            if interval not in [1, 5, 15, 25, 60]:
+                raise Exception("interval value must be ['1','5','15','25','60']")
+            payload = json_dumps({
+                "securityId": security_id,
+                "exchangeSegment": exchange_segment,
+                "instrument": instrument_type,
+                "interval": interval,
+                "fromDate": from_date,
+                "toDate": to_date,
+            })
+            resp = await self.session.post(
+                url, data=payload, headers=self.header, ssl=self._ssl()
+            )
+            return await self._parse_response(resp)
+        except Exception as e:
+            logging.error("Exception in AsyncDhanHQ>>intraday_minute_data: %s", e)
+            return {"status": "failure", "remarks": str(e), "data": ""}
+
+    async def historical_daily_data(
+        self,
+        security_id,
+        exchange_segment,
+        instrument_type,
+        from_date,
+        to_date,
+        expiry_code=0,
+    ):
+        try:
+            url = self.base_url + "/charts/historical"
+            if expiry_code not in [0, 1, 2, 3]:
+                raise Exception("expiry_code value must be ['0','1','2','3']")
+            payload = json_dumps({
+                "securityId": security_id,
+                "exchangeSegment": exchange_segment,
+                "instrument": instrument_type,
+                "expiryCode": expiry_code,
+                "fromDate": from_date,
+                "toDate": to_date,
+            })
+            resp = await self.session.post(
+                url, data=payload, headers=self.header, ssl=self._ssl()
+            )
+            return await self._parse_response(resp)
+        except Exception as e:
+            logging.error("Exception in AsyncDhanHQ>>historical_daily_data: %s", e)
+            return {"status": "failure", "remarks": str(e), "data": ""}
+
+    async def ticker_data(self, securities):
+        try:
+            url = self.base_url + "/marketfeed/ltp"
+            payload = json_dumps({k: v for k, v in securities.items()})
+            headers = {
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "access-token": self.access_token,
+                "client-id": self.client_id,
+            }
+            resp = await self.session.post(
+                url, data=payload, headers=headers, ssl=self._ssl()
+            )
+            return await self._parse_response(resp)
+        except Exception as e:
+            logging.error("Exception in AsyncDhanHQ>>ticker_data: %s", e)
+            return {"status": "failure", "remarks": str(e), "data": ""}
+
+    async def ohlc_data(self, securities):
+        try:
+            url = self.base_url + "/marketfeed/ohlc"
+            payload = json_dumps({k: v for k, v in securities.items()})
+            headers = {
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "access-token": self.access_token,
+                "client-id": self.client_id,
+            }
+            resp = await self.session.post(
+                url, data=payload, headers=headers, ssl=self._ssl()
+            )
+            return await self._parse_response(resp)
+        except Exception as e:
+            logging.error("Exception in AsyncDhanHQ>>ohlc_data: %s", e)
+            return {"status": "failure", "remarks": str(e), "data": ""}
+
+    async def quote_data(self, securities):
+        try:
+            url = self.base_url + "/marketfeed/quote"
+            payload = json_dumps({k: v for k, v in securities.items()})
+            headers = {
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "access-token": self.access_token,
+                "client-id": self.client_id,
+            }
+            resp = await self.session.post(
+                url, data=payload, headers=headers, ssl=self._ssl()
+            )
+            return await self._parse_response(resp)
+        except Exception as e:
+            logging.error("Exception in AsyncDhanHQ>>quote_data: %s", e)
+            return {"status": "failure", "remarks": str(e), "data": ""}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-asyncio
 responses
+aiohttp

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1,0 +1,58 @@
+import json
+import pytest
+
+from dhanhq.async_client import AsyncDhanHQ
+
+
+class DummyResponse:
+    def __init__(self, data, status=200):
+        self._data = data
+        self.status = status
+
+    async def json(self, content_type=None):
+        return self._data
+
+
+class DummySession:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    async def post(self, url, **kwargs):
+        self.calls.append(("POST", url, kwargs))
+        return DummyResponse(self.responses.pop(0))
+
+    async def get(self, url, **kwargs):
+        self.calls.append(("GET", url, kwargs))
+        return DummyResponse(self.responses.pop(0))
+
+    async def close(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_async_place_order():
+    session = DummySession([{"order_id": "1"}])
+    api = AsyncDhanHQ("CID", "TOKEN", session=session)
+    resp = await api.place_order(
+        security_id="123",
+        exchange_segment=api.NSE,
+        transaction_type=api.BUY,
+        quantity=1,
+        order_type=api.MARKET,
+        product_type=api.INTRA,
+        price=0,
+    )
+    assert resp["status"] == "success"
+    body = json.loads(session.calls[0][2]["data"])
+    assert body["dhanClientId"] == "CID"
+
+
+@pytest.mark.asyncio
+async def test_async_get_positions():
+    session = DummySession([{"positions": []}])
+    api = AsyncDhanHQ("CID", "TOKEN", session=session)
+    resp = await api.get_positions()
+    assert resp["data"] == {"positions": []}
+    assert session.calls[0][0] == "GET"
+


### PR DESCRIPTION
## Summary
- implement optional `AsyncDhanHQ` client using aiohttp
- expose `AsyncDhanHQ` in package
- document async usage
- add aiohttp to dev requirements
- add asyncio tests for async client

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851bb5e54488321a20b0913d376d39c