### PR TITLE
Add Super Order API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,19 @@ dhan.place_super_order(
 )
 # Required parameters: security_id, exchange_segment, transaction_type,
 # product_type, order_type, quantity, price, target and stop_loss
+
+# Get Super Orders
+dhan.get_super_orders()
+
+# Modify Super Order
+dhan.modify_super_order(
+    order_id="12345",
+    leg_name="ENTRY_LEG",
+    price=1910
+)
+
+# Cancel Super Order
+dhan.cancel_super_order("12345", "ENTRY_LEG")
 ```
 
 ### Async Usage

--- a/dhanhq/dhanhq.py
+++ b/dhanhq/dhanhq.py
@@ -19,6 +19,9 @@ from datetime import datetime, timedelta, timezone
 class dhanhq:
     """DhanHQ Class to interact with REST APIs"""
 
+    # expose the browser open function for testing
+    web_open = staticmethod(web_open)
+
     """Constants for Exchange Segment"""
     NSE = "NSE_EQ"
     BSE = "BSE_EQ"
@@ -765,10 +768,10 @@ class dhanhq:
             logging.error("Exception in dhanhq>>modify_super_order: %s", e)
             return {"status": "failure", "remarks": str(e), "data": ""}
 
-    def cancel_super_order(self, order_id):
-        """Cancel a Super Order using the order ID."""
+    def cancel_super_order(self, order_id, order_leg):
+        """Cancel a specific leg of a Super Order using the order and leg ID."""
         try:
-            url = self.base_url + f"/super/orders/{order_id}"
+            url = self.base_url + f"/super/orders/{order_id}/{order_leg}"
             response = self.session.delete(url, headers=self.header, timeout=self.timeout)
             return self._parse_response(response)
         except Exception as e:

--- a/tests/test_dhanhq.py
+++ b/tests/test_dhanhq.py
@@ -94,10 +94,65 @@ def test_modify_super_order_success():
 @responses.activate
 def test_cancel_super_order_success():
     api = dhanhq('CID', 'TOKEN')
-    url = api.base_url + '/super/orders/123'
+    url = api.base_url + '/super/orders/123/ENTRY_LEG'
     responses.add(responses.DELETE, url, json={"status": "cancelled"}, status=200)
 
-    resp = api.cancel_super_order('123')
+    resp = api.cancel_super_order('123', 'ENTRY_LEG')
 
     assert resp['status'] == 'success'
     assert resp['data'] == {"status": "cancelled"}
+
+
+@responses.activate
+def test_get_super_orders_failure():
+    api = dhanhq('CID', 'TOKEN')
+    url = api.base_url + '/super/orders'
+    responses.add(responses.GET, url, json={'err': 'bad'}, status=400)
+
+    resp = api.get_super_orders()
+
+    assert resp['status'] == 'failure'
+
+
+@responses.activate
+def test_place_super_order_failure():
+    api = dhanhq('CID', 'TOKEN')
+    url = api.base_url + '/super/orders'
+    responses.add(responses.POST, url, json={'err': 'bad'}, status=400)
+
+    resp = api.place_super_order(
+        security_id='1',
+        exchange_segment=api.NSE,
+        transaction_type=api.BUY,
+        product_type=api.INTRA,
+        order_type=api.LIMIT,
+        quantity=1,
+        price=10,
+        trigger_price=9,
+        target=12,
+        stop_loss=8
+    )
+
+    assert resp['status'] == 'failure'
+
+
+@responses.activate
+def test_modify_super_order_failure():
+    api = dhanhq('CID', 'TOKEN')
+    url = api.base_url + '/super/orders/123'
+    responses.add(responses.PUT, url, json={'err': 'bad'}, status=400)
+
+    resp = api.modify_super_order('123', leg_name='ENTRY_LEG', price=11)
+
+    assert resp['status'] == 'failure'
+
+
+@responses.activate
+def test_cancel_super_order_failure():
+    api = dhanhq('CID', 'TOKEN')
+    url = api.base_url + '/super/orders/123/ENTRY_LEG'
+    responses.add(responses.DELETE, url, json={'err': 'bad'}, status=400)
+
+    resp = api.cancel_super_order('123', 'ENTRY_LEG')
+
+    assert resp['status'] == 'failure'


### PR DESCRIPTION
## Summary
- expose `web_open` on the `dhanhq` class for easier patching
- allow cancelling specific super order legs
- document super order usage in README
- add tests for super order success and failure cases

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851bcbbb1348321b3f90fc20ea90a5e