### PR TITLE
Add bulk TPIN form API

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ dhan.open_browser_for_tpin(isin='INE00IN01015',
     qty=1,
     exchange='NSE')
 
+# Bulk TPIN form HTML
+dhan.generate_bulk_tpin_form([
+    {"isin": 'INE00IN01015', "qty": 1, "exchange": 'NSE'}
+])
+
 # EDIS Status and Inquiry
 dhan.edis_inquiry()
 

--- a/dhanhq/dhanhq.py
+++ b/dhanhq/dhanhq.py
@@ -844,6 +844,43 @@ class dhanhq:
                 "data": "",
             }
 
+    def generate_bulk_tpin_form(self, requests_list):
+        """Generate HTML form for bulk eDIS authorization.
+
+        Args:
+            requests_list (list): List of dictionaries containing ``isin``,
+                ``qty`` and ``exchange`` for each security. ``segment`` can be
+                provided for every item and defaults to ``EQ`` by the API.
+
+        Returns:
+            dict: Parsed API response with ``edisFormHtml`` content cleaned of
+            escape characters.
+        """
+        try:
+            url = self.base_url + "/edis/bulkform"
+            payload = {"edisRequests": requests_list}
+            data = json_dumps(payload)
+            response = self.session.post(
+                url, headers=self.header, data=data, timeout=self.timeout
+            )
+            result = self._parse_response(response)
+            if (
+                result.get("status") == "success"
+                and isinstance(result.get("data"), dict)
+                and "edisFormHtml" in result["data"]
+            ):
+                result["data"]["edisFormHtml"] = result["data"][
+                    "edisFormHtml"
+                ].replace("\\", "")
+            return result
+        except Exception as e:
+            logging.error("Exception in dhanhq>>generate_bulk_tpin_form : %s", e)
+            return {
+                "status": "failure",
+                "remarks": str(e),
+                "data": "",
+            }
+
     def edis_inquiry(self, isin):
         """
         Inquire about the eDIS status of the provided ISIN.


### PR DESCRIPTION
## Summary
- add `generate_bulk_tpin_form` for POST `/edis/bulkform`
- document bulk TPIN usage
- test new helper
- fix test monkeypatch path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851bcbda8ec8321a435f6d96dfc64af