### PR TITLE
Add kill switch tests

### DIFF
--- a/dhanhq/dhanhq.py
+++ b/dhanhq/dhanhq.py
@@ -929,6 +929,20 @@ class dhanhq:
                 "data": "",
             }
 
+    def get_kill_switch_status(self):
+        """Retrieve current kill switch status for the account."""
+        try:
+            url = f"{self.base_url}/killswitch"
+            response = self.session.get(url, headers=self.header, timeout=self.timeout)
+            return self._parse_response(response)
+        except Exception as e:
+            logging.error("Exception in dhanhq>>get_kill_switch_status : %s", e)
+            return {
+                "status": "failure",
+                "remarks": str(e),
+                "data": "",
+            }
+
     def get_fund_limits(self):
         """
         Get all information of your trading account like balance, margin utilized, collateral, etc.

--- a/tests/test_dhanhq_more.py
+++ b/tests/test_dhanhq_more.py
@@ -102,6 +102,26 @@ def test_kill_switch_failure():
     assert resp['status'] == 'failure'
 
 
+@responses.activate
+def test_kill_switch_success():
+    api = dhanhq('CID', 'TOKEN')
+    url = api.base_url + '/killswitch?killSwitchStatus=DEACTIVATE'
+    responses.add(responses.POST, url, json={'status': 'off'}, status=200)
+    resp = api.kill_switch('deactivate')
+    assert resp['status'] == 'success'
+    assert resp['data'] == {'status': 'off'}
+
+
+@responses.activate
+def test_get_kill_switch_status_success():
+    api = dhanhq('CID', 'TOKEN')
+    url = api.base_url + '/killswitch'
+    responses.add(responses.GET, url, json={'status': 'ACTIVE'}, status=200)
+    resp = api.get_kill_switch_status()
+    assert resp['status'] == 'success'
+    assert resp['data'] == {'status': 'ACTIVE'}
+
+
 def test_convert_to_date_time():
     api = dhanhq('CID', 'TOKEN')
     dt = api.convert_to_date_time(0)


### PR DESCRIPTION
## Summary
- test kill switch success and status retrieval
- implement `get_kill_switch_status` helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851bf955e6c832180850e3db27d8bcf