### PR TITLE
Add simple Flask frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,21 @@ def run_order_update():
 run_order_update()
 ```
 
+## Simple Frontend
+
+A minimal Flask application is provided in `webapp/` which demonstrates how to
+place orders and view your day's orders using this library.
+
+Run it with your Dhan credentials:
+
+```bash
+export DHAN_CLIENT_ID=your_id
+export DHAN_ACCESS_TOKEN=your_token
+python -m webapp.app
+```
+
+Open `http://localhost:5000` in your browser to access the interface.
+
 ## Changelog
 
 [Check release notes](https://github.com/dhan-oss/DhanHQ-py/releases)

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,0 +1,7 @@
+from webapp.app import app
+
+
+def test_index_page():
+    client = app.test_client()
+    resp = client.get('/')
+    assert resp.status_code == 200

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,47 @@
+import os
+from flask import Flask, render_template, request, redirect, url_for, flash
+from dhanhq.dhanhq import dhanhq
+
+app = Flask(__name__)
+app.secret_key = "dhanhq-front"
+
+
+def get_api():
+    client_id = os.getenv("DHAN_CLIENT_ID")
+    access_token = os.getenv("DHAN_ACCESS_TOKEN")
+    if not client_id or not access_token:
+        raise RuntimeError("DHAN_CLIENT_ID and DHAN_ACCESS_TOKEN must be set")
+    return dhanhq(client_id, access_token)
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/place_order", methods=["POST"])
+def place_order():
+    api = get_api()
+    data = request.form
+    resp = api.place_order(
+        security_id=data["security_id"],
+        exchange_segment=data["exchange_segment"],
+        transaction_type=data["transaction_type"],
+        quantity=int(data["quantity"]),
+        order_type=data.get("order_type", api.MARKET),
+        product_type=data.get("product_type", api.INTRA),
+        price=float(data.get("price", 0)),
+    )
+    flash(resp.get("status"))
+    return redirect(url_for("index"))
+
+
+@app.route("/orders")
+def orders():
+    api = get_api()
+    resp = api.get_order_list()
+    return render_template("order_list.html", orders=resp.get("data", []))
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+<head>
+    <title>DhanHQ Frontend</title>
+</head>
+<body>
+    <h1>Place Order</h1>
+    <form action="/place_order" method="post">
+        Security ID: <input name="security_id"><br>
+        Exchange Segment:
+        <select name="exchange_segment">
+            <option value="NSE_EQ">NSE_EQ</option>
+            <option value="BSE_EQ">BSE_EQ</option>
+            <option value="NSE_FNO">NSE_FNO</option>
+        </select><br>
+        Transaction Type:
+        <select name="transaction_type">
+            <option value="BUY">BUY</option>
+            <option value="SELL">SELL</option>
+        </select><br>
+        Quantity: <input name="quantity" type="number"><br>
+        Order Type:
+        <select name="order_type">
+            <option value="MARKET">MARKET</option>
+            <option value="LIMIT">LIMIT</option>
+        </select><br>
+        Product Type:
+        <select name="product_type">
+            <option value="INTRADAY">INTRADAY</option>
+            <option value="CNC">CNC</option>
+        </select><br>
+        Price: <input name="price" type="number" step="0.01"><br>
+        <button type="submit">Submit</button>
+    </form>
+    <a href="/orders">View Orders</a>
+    {% with messages = get_flashed_messages() %}
+      {% if messages %}
+        <ul>
+        {% for message in messages %}
+          <li>{{ message }}</li>
+        {% endfor %}
+        </ul>
+      {% endif %}
+    {% endwith %}
+</body>
+</html>

--- a/webapp/templates/order_list.html
+++ b/webapp/templates/order_list.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<head>
+    <title>Order List</title>
+</head>
+<body>
+    <h1>Orders</h1>
+    <table border="1">
+        <tr><th>Order ID</th><th>Status</th></tr>
+        {% for order in orders %}
+        <tr>
+            <td>{{ order.get('orderId') }}</td>
+            <td>{{ order.get('status') }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+    <a href="/">Back</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal Flask app in `webapp/` for placing orders and viewing order lists
- provide HTML templates for the new frontend
- document how to run the frontend
- add a test ensuring the webapp loads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68526b47a3108321b1be117921fafbaf