### PR TITLE
Add CLI frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,22 @@ You can install the package via pip
 pip install dhanhq
 ```
 
+### Command Line Interface
+
+After installing, a simple CLI is available which exposes a few common API
+operations. Run the module with your credentials and a command, for example:
+
+```bash
+python -m dhanhq CLIENT_ID ACCESS_TOKEN list-orders
+```
+
+Available commands are:
+
+- `list-orders` – show today's orders
+- `get-order ORDER_ID` – fetch details of a specific order
+- `place-order` – create a basic order (see `-h` for required arguments)
+- `positions` – list current positions
+
 
 
 ### Hands-on API

--- a/dhanhq/__main__.py
+++ b/dhanhq/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/dhanhq/cli.py
+++ b/dhanhq/cli.py
@@ -1,0 +1,58 @@
+import argparse
+import json
+from .dhanhq import dhanhq
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="CLI for DhanHQ API")
+    parser.add_argument("client_id", help="Dhan client id")
+    parser.add_argument("access_token", help="Dhan access token")
+    subparsers = parser.add_subparsers(dest="command")
+
+    subparsers.add_parser("list-orders", help="List today's orders")
+
+    get_order = subparsers.add_parser("get-order", help="Get order by id")
+    get_order.add_argument("order_id")
+
+    place = subparsers.add_parser("place-order", help="Place a simple order")
+    place.add_argument("security_id")
+    place.add_argument("exchange_segment")
+    place.add_argument("transaction_type")
+    place.add_argument("quantity", type=int)
+    place.add_argument("order_type")
+    place.add_argument("product_type")
+    place.add_argument("price", type=float)
+
+    subparsers.add_parser("positions", help="Get open positions")
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    api = dhanhq(args.client_id, args.access_token)
+
+    if args.command == "list-orders":
+        resp = api.get_order_list()
+    elif args.command == "get-order":
+        resp = api.get_order_by_id(args.order_id)
+    elif args.command == "place-order":
+        resp = api.place_order(
+            security_id=args.security_id,
+            exchange_segment=args.exchange_segment,
+            transaction_type=args.transaction_type,
+            quantity=args.quantity,
+            order_type=args.order_type,
+            product_type=args.product_type,
+            price=args.price,
+        )
+    elif args.command == "positions":
+        resp = api.get_positions()
+    else:
+        return
+
+    print(json.dumps(resp, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement simple CLI to interact with DhanHQ API
- allow launching CLI via `python -m dhanhq`
- document CLI usage in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68526b47a3108321b1be117921fafbaf