### PR TITLE
Add Flask frontend example

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,21 @@ def run_order_update():
 run_order_update()
 ```
 
+## Frontend
+
+A minimal Flask application is provided for manually testing the APIs.
+
+Install the dependency and run the app:
+
+```bash
+pip install flask
+python frontend/app.py
+```
+
+`CLIENT_ID` and `ACCESS_TOKEN` environment variables must be set before running
+the application. It exposes a form at `http://localhost:5000/` to place orders
+and an `/orders` page to view the day's orders.
+
 ## Changelog
 
 [Check release notes](https://github.com/dhan-oss/DhanHQ-py/releases)

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1,0 +1,47 @@
+import os
+from flask import Flask, render_template, request, redirect, url_for, flash
+from dhanhq.dhanhq import dhanhq
+
+client_id = os.environ.get("CLIENT_ID")
+access_token = os.environ.get("ACCESS_TOKEN")
+
+if not client_id or not access_token:
+    raise RuntimeError("CLIENT_ID and ACCESS_TOKEN environment variables must be set")
+
+app = Flask(__name__)
+app.secret_key = os.environ.get("SECRET_KEY", "change-me")
+
+dhan = dhanhq(client_id, access_token)
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/order", methods=["POST"])
+def order():
+    form = request.form
+    result = dhan.place_order(
+        security_id=form["security_id"],
+        exchange_segment=form["exchange_segment"],
+        transaction_type=form["transaction_type"],
+        quantity=form["quantity"],
+        order_type=form["order_type"],
+        product_type=form["product_type"],
+        price=form.get("price", 0),
+        trigger_price=form.get("trigger_price", 0),
+    )
+    flash(str(result))
+    return redirect(url_for("index"))
+
+
+@app.route("/orders")
+def orders():
+    result = dhan.get_order_list()
+    orders = result.get("data", []) if isinstance(result, dict) else []
+    return render_template("orders.html", orders=orders)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Place Order</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+<div class="container">
+  <h1 class="mb-4">Place Order</h1>
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      <div class="alert alert-info">{{ messages[0] }}</div>
+    {% endif %}
+  {% endwith %}
+  <form method="post" action="{{ url_for('order') }}">
+    <div class="mb-3">
+      <label class="form-label">Security ID</label>
+      <input class="form-control" name="security_id" required>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Exchange Segment</label>
+      <input class="form-control" name="exchange_segment" value="NSE_EQ" required>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Transaction Type</label>
+      <select class="form-select" name="transaction_type">
+        <option value="BUY">BUY</option>
+        <option value="SELL">SELL</option>
+      </select>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Product Type</label>
+      <input class="form-control" name="product_type" value="INTRADAY">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Order Type</label>
+      <input class="form-control" name="order_type" value="MARKET">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Quantity</label>
+      <input type="number" class="form-control" name="quantity" required>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Price</label>
+      <input type="number" class="form-control" name="price" value="0">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Trigger Price</label>
+      <input type="number" class="form-control" name="trigger_price" value="0">
+    </div>
+    <button type="submit" class="btn btn-primary">Submit</button>
+  </form>
+  <hr>
+  <a href="{{ url_for('orders') }}">View Orders</a>
+</div>
+</body>
+</html>

--- a/frontend/templates/orders.html
+++ b/frontend/templates/orders.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Orders</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+<div class="container">
+  <h1 class="mb-4">Orders</h1>
+  <table class="table table-bordered">
+    <thead><tr><th>#</th><th>Data</th></tr></thead>
+    <tbody>
+      {% if orders %}
+        {% for o in orders %}
+          <tr><td>{{ loop.index }}</td><td><pre class="mb-0">{{ o | tojson(indent=2) }}</pre></td></tr>
+        {% endfor %}
+      {% else %}
+        <tr><td colspan="2">No orders found</td></tr>
+      {% endif %}
+    </tbody>
+  </table>
+  <a href="{{ url_for('index') }}">Back</a>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a small Flask application under `frontend/` to demo order placement
- include simple Bootstrap templates
- document how to run the frontend

## Testing
- `flake8` *(fails: numerous style violations)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68526f3a0da48321b765983883dc8478