### PR TITLE
Add simple login flow for webapp

### DIFF
--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,38 +1,15 @@
 <!doctype html>
 <html>
 <head>
-    <title>DhanHQ Frontend</title>
+    <title>Login</title>
 </head>
 <body>
-    <h1>Place Order</h1>
-    <form action="/place_order" method="post">
-        Security ID: <input name="security_id"><br>
-        Exchange Segment:
-        <select name="exchange_segment">
-            <option value="NSE_EQ">NSE_EQ</option>
-            <option value="BSE_EQ">BSE_EQ</option>
-            <option value="NSE_FNO">NSE_FNO</option>
-        </select><br>
-        Transaction Type:
-        <select name="transaction_type">
-            <option value="BUY">BUY</option>
-            <option value="SELL">SELL</option>
-        </select><br>
-        Quantity: <input name="quantity" type="number"><br>
-        Order Type:
-        <select name="order_type">
-            <option value="MARKET">MARKET</option>
-            <option value="LIMIT">LIMIT</option>
-        </select><br>
-        Product Type:
-        <select name="product_type">
-            <option value="INTRADAY">INTRADAY</option>
-            <option value="CNC">CNC</option>
-        </select><br>
-        Price: <input name="price" type="number" step="0.01"><br>
-        <button type="submit">Submit</button>
+    <h1>Login</h1>
+    <form action="/login" method="post">
+        Username: <input name="username"><br>
+        Password: <input name="password" type="password"><br>
+        <button type="submit">Login</button>
     </form>
-    <a href="/orders">View Orders</a>
     {% with messages = get_flashed_messages() %}
       {% if messages %}
         <ul>

--- a/webapp/templates/order_list.html
+++ b/webapp/templates/order_list.html
@@ -14,6 +14,6 @@
         </tr>
         {% endfor %}
     </table>
-    <a href="/">Back</a>
+    <a href="/trade">Back</a>
 </body>
 </html>

--- a/webapp/templates/trading.html
+++ b/webapp/templates/trading.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+<head>
+    <title>DhanHQ Frontend</title>
+</head>
+<body>
+    <h1>Place Order</h1>
+    <form action="/place_order" method="post">
+        Security ID: <input name="security_id"><br>
+        Exchange Segment:
+        <select name="exchange_segment">
+            <option value="NSE_EQ">NSE_EQ</option>
+            <option value="BSE_EQ">BSE_EQ</option>
+            <option value="NSE_FNO">NSE_FNO</option>
+        </select><br>
+        Transaction Type:
+        <select name="transaction_type">
+            <option value="BUY">BUY</option>
+            <option value="SELL">SELL</option>
+        </select><br>
+        Quantity: <input name="quantity" type="number"><br>
+        Order Type:
+        <select name="order_type">
+            <option value="MARKET">MARKET</option>
+            <option value="LIMIT">LIMIT</option>
+        </select><br>
+        Product Type:
+        <select name="product_type">
+            <option value="INTRADAY">INTRADAY</option>
+            <option value="CNC">CNC</option>
+        </select><br>
+        Price: <input name="price" type="number" step="0.01"><br>
+        <button type="submit">Submit</button>
+    </form>
+    <a href="/orders">View Orders</a>
+    {% with messages = get_flashed_messages() %}
+      {% if messages %}
+        <ul>
+        {% for message in messages %}
+          <li>{{ message }}</li>
+        {% endfor %}
+        </ul>
+      {% endif %}
+    {% endwith %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement login page that checks hardcoded admin credentials
- add session-based login in `webapp/app.py`
- move trading interface to new `trading.html`
- update order list back link

## Testing
- `pytest tests/test_webapp.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68527554ddbc8321a6a3e69d32a26158