### PR TITLE
Enhance CLI with backtesting & paper trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ Available commands are:
 - `get-order ORDER_ID` – fetch details of a specific order
 - `place-order` – create a basic order (see `-h` for required arguments)
 - `positions` – list current positions
+- `backtest DATA.csv` – compute simple profit from a CSV of closing prices
+- `paper-start` / `paper-stop` – manage a paper trading session
+- `upload-strategy FILE.json` – add strategy parameters from a JSON file
 
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import json
+import shutil
+import sqlite3
+import tempfile
+
+import pandas as pd
+import dhanhq.cli as cli
+
+
+def run_cli(monkeypatch, args):
+    monkeypatch.setattr(sys, "argv", ["prog"] + args)
+    out = []
+
+    def fake_print(s):
+        out.append(s)
+
+    monkeypatch.setattr("builtins.print", fake_print)
+    cli.main()
+    return json.loads(out[0]) if out else None
+
+
+def test_backtest_command(tmp_path, monkeypatch):
+    data = pd.DataFrame({"close": [100, 120]})
+    csv = tmp_path / "data.csv"
+    data.to_csv(csv, index=False)
+    result = run_cli(monkeypatch, ["CID", "TOKEN", "backtest", str(csv)])
+    assert result["profit"] == 20
+
+
+def test_paper_session_commands(tmp_path, monkeypatch):
+    session_file = tmp_path / "session.txt"
+    monkeypatch.setenv("PAPER_SESSION_FILE", str(session_file))
+    run_cli(monkeypatch, ["CID", "TOKEN", "paper-start"])
+    assert session_file.read_text() == "running"
+    run_cli(monkeypatch, ["CID", "TOKEN", "paper-stop"])
+    assert session_file.read_text() == "stopped"
+
+
+def test_upload_strategy_command(tmp_path, monkeypatch):
+    db_copy = tmp_path / "strategies.db"
+    shutil.copyfile(os.path.join("webapp", "strategies.db"), db_copy)
+    monkeypatch.setenv("STRATEGIES_DB", str(db_copy))
+    json_file = tmp_path / "params.json"
+    params = {
+        "name": "test",
+        "entry_time": "09:15",
+        "exit_time": "15:15",
+        "lots": 1,
+        "call_transaction_type": "SELL",
+        "call_strike_offset": 0,
+        "put_transaction_type": "SELL",
+        "put_strike_offset": 0,
+        "stop_loss_amount": 0,
+        "target_profit_amount": 0,
+        "product_type": "INTRADAY",
+    }
+    json_file.write_text(json.dumps(params))
+    result = run_cli(monkeypatch, ["CID", "TOKEN", "upload-strategy", str(json_file)])
+    conn = sqlite3.connect(db_copy)
+    cur = conn.cursor()
+    cur.execute("SELECT name FROM strategy WHERE id=?", (result["id"],))
+    row = cur.fetchone()
+    conn.close()
+    assert row and row[0] == "test"

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -223,6 +223,26 @@ def delete_strategy(strategy_id):
     except Exception as e:
         flash(f"Error deleting strategy: {e}", 'danger')
     return redirect(url_for("manage_strategies"))
+
+
+@app.route("/trade")
+def trade_page():
+    if not session.get("logged_in"):
+        return redirect(url_for("index"))
+    return render_template("trading.html")
+
+
+@app.route("/orders")
+def orders_page():
+    if not session.get("logged_in"):
+        return redirect(url_for("index"))
+    api = get_api()
+    orders = []
+    if api:
+        resp = api.get_order_list()
+        if resp.get("status") == "success":
+            orders = resp.get("data", [])
+    return render_template("order_list.html", orders=orders)
     
 if __name__ == "__main__":
     with app.app_context():


### PR DESCRIPTION
## Summary
- extend CLI with backtesting, paper trading and strategy upload commands
- expose new routes for `/trade` and `/orders`
- add regression tests for CLI additions
- document new CLI usage in README

## Testing
- `pip install -q -r requirements-dev.txt`
- `pip install -q Flask SQLAlchemy flask-migrate pandas apscheduler`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853b7d3b13c832188056e2dd32b3754