### PR TITLE
Add analytics tracking and export

### DIFF
--- a/migrations/versions/e0a67c18c6d4_add_trade_and_daily_pnl_tables.py
+++ b/migrations/versions/e0a67c18c6d4_add_trade_and_daily_pnl_tables.py
@@ -1,0 +1,36 @@
+"""Add trade result and daily pnl tables
+
+Revision ID: e0a67c18c6d4
+Revises: df9491b6f34f
+Create Date: 2025-06-19 02:00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'e0a67c18c6d4'
+down_revision = 'df9491b6f34f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'trade_result',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('strategy_id', sa.Integer(), sa.ForeignKey('strategy.id')),
+        sa.Column('timestamp', sa.DateTime(), nullable=False),
+        sa.Column('pnl', sa.Float(), nullable=False),
+        sa.Column('reason', sa.String(length=50), nullable=True),
+    )
+    op.create_table(
+        'daily_pnl',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('day', sa.Date(), nullable=False, unique=True),
+        sa.Column('pnl', sa.Float(), nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_table('daily_pnl')
+    op.drop_table('trade_result')

--- a/webapp/templates/analytics.html
+++ b/webapp/templates/analytics.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block title %}Analytics{% endblock %}
+{% block content %}
+<div class="container">
+  <h2 class="mb-3">Performance Analytics</h2>
+  <canvas id="cumChart"></canvas>
+  <canvas id="ddChart" class="mt-4"></canvas>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+fetch('{{ url_for('analytics_data') }}').then(r=>r.json()).then(data=>{
+  const labels=data.dates;
+  new Chart(document.getElementById('cumChart'),{type:'line',data:{labels:labels,datasets:[{label:'Cumulative P\u0026L',data:data.cumulative}]}});
+  new Chart(document.getElementById('ddChart'),{type:'line',data:{labels:labels,datasets:[{label:'Drawdown',data:data.drawdown}]}});
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- track trade results and daily P&L
- expose performance analytics endpoint and charts
- export trading logs as CSV
- add tests for analytics endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853bc4eb3888321bd9a8a8534b81bfe