### PR TITLE
Rename AsyncDhanhq class

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,10 +258,10 @@ dhan.cancel_super_order("12345", "ENTRY_LEG")
 ### Async Usage
 ```python
 import asyncio
-from dhanhq.async_httpx import AsyncDhanhq
+from dhanhq.async_httpx import AsyncDhanHQ
 
 async def main():
-    api = AsyncDhanhq("client_id", "access_token")
+    api = AsyncDhanHQ("client_id", "access_token")
     await api.place_order(
         security_id="1333",
         exchange_segment=api.NSE,

--- a/dhanhq/__init__.py
+++ b/dhanhq/__init__.py
@@ -2,13 +2,13 @@
 
 from .dhanhq import dhanhq
 from .async_client import AsyncDhanHQ
-from .async_httpx import AsyncDhanhq
+from .async_httpx import AsyncDhanHQ
 from .backtesting import BacktestEngine, load_intraday_data, load_daily_data
 
 __all__ = [
     "dhanhq",
     "AsyncDhanHQ",
-    "AsyncDhanhq",
+    "AsyncDhanHQ",
     "BacktestEngine",
     "load_intraday_data",
     "load_daily_data",

--- a/dhanhq/async_httpx.py
+++ b/dhanhq/async_httpx.py
@@ -2,7 +2,7 @@ import logging
 import httpx
 from json import dumps as json_dumps
 
-class AsyncDhanhq:
+class AsyncDhanHQ:
     """Asynchronous variant of :class:`dhanhq.dhanhq` using ``httpx.AsyncClient``."""
 
     # Exchange constants
@@ -74,7 +74,7 @@ class AsyncDhanhq:
                 "data": python_response,
             }
         except Exception as e:  # pragma: no cover - defensive
-            logging.warning("Exception in AsyncDhanhq>>_parse_response: %s", e)
+            logging.warning("Exception in AsyncDhanHQ>>_parse_response: %s", e)
             return {"status": "failure", "remarks": str(e), "data": ""}
 
     async def get_order_list(self):
@@ -83,7 +83,7 @@ class AsyncDhanhq:
             resp = await self.session.get(url, headers=self.header)
             return await self._parse_response(resp)
         except Exception as e:  # pragma: no cover - defensive
-            logging.error("Exception in AsyncDhanhq>>get_order_list : %s", e)
+            logging.error("Exception in AsyncDhanHQ>>get_order_list : %s", e)
             return {"status": "failure", "remarks": str(e), "data": ""}
 
     async def get_order_by_id(self, order_id):
@@ -92,7 +92,7 @@ class AsyncDhanhq:
             resp = await self.session.get(url, headers=self.header)
             return await self._parse_response(resp)
         except Exception as e:  # pragma: no cover - defensive
-            logging.error("Exception in AsyncDhanhq>>get_order_by_id : %s", e)
+            logging.error("Exception in AsyncDhanHQ>>get_order_by_id : %s", e)
             return {"status": "failure", "remarks": str(e), "data": ""}
 
     async def place_order(
@@ -141,7 +141,7 @@ class AsyncDhanhq:
             resp = await self.session.post(url, headers=self.header, data=json_dumps(payload))
             return await self._parse_response(resp)
         except Exception as e:  # pragma: no cover - defensive
-            logging.error("Exception in AsyncDhanhq>>place_order: %s", e)
+            logging.error("Exception in AsyncDhanHQ>>place_order: %s", e)
             return {"status": "failure", "remarks": str(e), "data": ""}
 
     async def get_positions(self):
@@ -150,7 +150,7 @@ class AsyncDhanhq:
             resp = await self.session.get(url, headers=self.header)
             return await self._parse_response(resp)
         except Exception as e:  # pragma: no cover - defensive
-            logging.error("Exception in AsyncDhanhq>>get_positions: %s", e)
+            logging.error("Exception in AsyncDhanHQ>>get_positions: %s", e)
             return {"status": "failure", "remarks": str(e), "data": ""}
 
     async def intraday_minute_data(
@@ -177,7 +177,7 @@ class AsyncDhanhq:
             resp = await self.session.post(url, headers=self.header, data=payload)
             return await self._parse_response(resp)
         except Exception as e:  # pragma: no cover - defensive
-            logging.error("Exception in AsyncDhanhq>>intraday_minute_data: %s", e)
+            logging.error("Exception in AsyncDhanHQ>>intraday_minute_data: %s", e)
             return {"status": "failure", "remarks": str(e), "data": ""}
 
     async def historical_daily_data(
@@ -204,7 +204,7 @@ class AsyncDhanhq:
             resp = await self.session.post(url, headers=self.header, data=payload)
             return await self._parse_response(resp)
         except Exception as e:  # pragma: no cover - defensive
-            logging.error("Exception in AsyncDhanhq>>historical_daily_data: %s", e)
+            logging.error("Exception in AsyncDhanHQ>>historical_daily_data: %s", e)
             return {"status": "failure", "remarks": str(e), "data": ""}
 
     async def ticker_data(self, securities):
@@ -220,7 +220,7 @@ class AsyncDhanhq:
             resp = await self.session.post(url, headers=headers, data=payload)
             return await self._parse_response(resp)
         except Exception as e:  # pragma: no cover - defensive
-            logging.error("Exception in AsyncDhanhq>>ticker_data: %s", e)
+            logging.error("Exception in AsyncDhanHQ>>ticker_data: %s", e)
             return {"status": "failure", "remarks": str(e), "data": ""}
 
     async def ohlc_data(self, securities):
@@ -236,7 +236,7 @@ class AsyncDhanhq:
             resp = await self.session.post(url, headers=headers, data=payload)
             return await self._parse_response(resp)
         except Exception as e:  # pragma: no cover - defensive
-            logging.error("Exception in AsyncDhanhq>>ohlc_data: %s", e)
+            logging.error("Exception in AsyncDhanHQ>>ohlc_data: %s", e)
             return {"status": "failure", "remarks": str(e), "data": ""}
 
     async def quote_data(self, securities):
@@ -252,5 +252,5 @@ class AsyncDhanhq:
             resp = await self.session.post(url, headers=headers, data=payload)
             return await self._parse_response(resp)
         except Exception as e:  # pragma: no cover - defensive
-            logging.error("Exception in AsyncDhanhq>>quote_data: %s", e)
+            logging.error("Exception in AsyncDhanHQ>>quote_data: %s", e)
             return {"status": "failure", "remarks": str(e), "data": ""}

--- a/tests/test_async_httpx.py
+++ b/tests/test_async_httpx.py
@@ -1,7 +1,7 @@
 import json
 import pytest
 
-from dhanhq.async_httpx import AsyncDhanhq
+from dhanhq.async_httpx import AsyncDhanHQ
 
 
 class DummyResponse:
@@ -33,7 +33,7 @@ class DummySession:
 @pytest.mark.asyncio
 async def test_async_httpx_place_order():
     session = DummySession([{"order_id": "1"}])
-    api = AsyncDhanhq("CID", "TOKEN", session=session)
+    api = AsyncDhanHQ("CID", "TOKEN", session=session)
     resp = await api.place_order(
         security_id="123",
         exchange_segment=api.NSE,
@@ -51,7 +51,7 @@ async def test_async_httpx_place_order():
 @pytest.mark.asyncio
 async def test_async_httpx_get_positions():
     session = DummySession([{"positions": []}])
-    api = AsyncDhanhq("CID", "TOKEN", session=session)
+    api = AsyncDhanHQ("CID", "TOKEN", session=session)
     resp = await api.get_positions()
     assert resp["data"] == {"positions": []}
     assert session.calls[0][0] == "GET"

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -246,24 +246,6 @@ def delete_strategy(strategy_id):
     return redirect(url_for("manage_strategies"))
 
 
-@app.route("/trade")
-def trade_page():
-    if not session.get("logged_in"):
-        return redirect(url_for("index"))
-    return render_template("trading.html")
-
-
-@app.route("/orders")
-def orders_page():
-    if not session.get("logged_in"):
-        return redirect(url_for("index"))
-    api = get_api()
-    orders = []
-    if api:
-        resp = api.get_order_list()
-        if resp.get("status") == "success":
-            orders = resp.get("data", [])
-    return render_template("order_list.html", orders=orders)
     
 if __name__ == "__main__":
     with app.app_context():


### PR DESCRIPTION
## Summary
- rename `AsyncDhanhq` to `AsyncDhanHQ`
- update exports and tests to use the new name
- remove duplicate route declarations to satisfy tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853c13b79f88321b631bae2a8b431b1