### PR TITLE
Fix duplicate route definition

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -246,24 +246,6 @@ def delete_strategy(strategy_id):
     return redirect(url_for("manage_strategies"))
 
 
-@app.route("/trade")
-def trade_page():
-    if not session.get("logged_in"):
-        return redirect(url_for("index"))
-    return render_template("trading.html")
-
-
-@app.route("/orders")
-def orders_page():
-    if not session.get("logged_in"):
-        return redirect(url_for("index"))
-    api = get_api()
-    orders = []
-    if api:
-        resp = api.get_order_list()
-        if resp.get("status") == "success":
-            orders = resp.get("data", [])
-    return render_template("order_list.html", orders=orders)
     
 if __name__ == "__main__":
     with app.app_context():


### PR DESCRIPTION
## Summary
- remove duplicate `/trade` and `/orders` routes in `webapp/app.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for requests/pandas/flask dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685422f898c483218cccaa988263afbb